### PR TITLE
[MODEBSNET-39] Renewal note is blank after update

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -30,7 +30,7 @@
   "provides": [
     {
       "id": "ebsconet",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": [

--- a/src/main/java/org/folio/ebsconet/mapper/OrdersMapper.java
+++ b/src/main/java/org/folio/ebsconet/mapper/OrdersMapper.java
@@ -50,7 +50,7 @@ public abstract class OrdersMapper {
   @Mapping(target = "publisherName", source = "line.publisher")
   @Mapping(target = "vendorAccountNumber", source = "line.vendorDetail.vendorAccount")
   @Mapping(target = "workflowStatus", source = "order.workflowStatus")
-  @Mapping(target = "renewalNote", source = "line.renewalNote")
+  @Mapping(target = "internalNote", source = "line.renewalNote")
   public abstract EbsconetOrderLine folioToEbsconet(PurchaseOrder order, PoLine line, Organization vendor);
 
   @Named("getFundCode")
@@ -89,7 +89,7 @@ public abstract class OrdersMapper {
     poLine.getDetails().setSubscriptionFrom(ebsconetOrderLine.getSubscriptionFromDate());
     poLine.getVendorDetail().setVendorAccount(ebsconetOrderLine.getVendorAccountNumber());
     poLine.setPublisher(ebsconetOrderLine.getPublisherName());
-    poLine.setRenewalNote(mappingDataHolder.getEbsconetOrderLine().getRenewalNote());
+    poLine.setRenewalNote(mappingDataHolder.getEbsconetOrderLine().getInternalNote());
 
     populateCostAndLocations(poLine, ebsconetOrderLine);
     removeZeroAmountLocations(poLine);

--- a/src/main/resources/swagger.api/schemas/mod-ebsconet/ebsconet_order_line.json
+++ b/src/main/resources/swagger.api/schemas/mod-ebsconet/ebsconet_order_line.json
@@ -34,7 +34,7 @@
       "description": "Publisher of the material",
       "readOnly": false
     },
-    "renewalNote": {
+    "internalNote": {
       "type": "string",
       "description": "Renewal note for this purchase order line"
     },

--- a/src/test/java/org/folio/ebsconet/OrdersServiceTest.java
+++ b/src/test/java/org/folio/ebsconet/OrdersServiceTest.java
@@ -224,7 +224,7 @@ class OrdersServiceTest {
     EbsconetOrderLine ebsconetOrderLine = getSampleEbsconetOrderLine("CODE", 1);
 
     var testRenewalNote = "Test renewal Note";
-    ebsconetOrderLine.renewalNote(testRenewalNote);
+    ebsconetOrderLine.internalNote(testRenewalNote);
     var poLineNumber = "10000-1";
     var polResult = new PoLineCollection();
     var poLine = new PoLine();


### PR DESCRIPTION
 ## Purpose
https://issues.folio.org/browse/MODEBSNET-39
Change 'renewalNote' field to 'internalNote' to satisfy ebsconet orders contract.
 ## Approach
Payload coming from ebsconet orders:
`{
   "vendor":"SREBSCO",
   "cancellationRestriction":false,
   "unitPrice":230.00,
   "currency":"USD",
   "vendorReferenceNumbers":[
      {
         "refNumber":"A9447438",
         "refNumberType":"Vendor continuation reference number"
      }
   ],
   "poLineNumber":"10290-1",
   "quantity":1,
   "fundCode":"AFRICAHIST:Prn",
   "publisherName":"UCLA CHICANO STUDIES RES CTR",
   "vendorAccountNumber":"BR6569501",
   "workflowStatus":"Open",
   "internalNote":"Update renewal note",
   "renewalDate":"2023-01-01T00:00:00+00:00",
   "type":"Renewal"
}`
renewalNote should be renamed to internalNote for correct mapping of this field to satisfy ebsconet orders contract