### PR TITLE
MODEBSNET-58: Delete beginFolioExecutionContext from TestBase

### DIFF
--- a/src/test/java/org/folio/ebsconet/TestBase.java
+++ b/src/test/java/org/folio/ebsconet/TestBase.java
@@ -6,9 +6,7 @@ import io.restassured.response.Response;
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.integration.XOkapiHeaders;
-import org.folio.spring.scope.FolioExecutionScopeExecutionContextManager;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -31,15 +29,6 @@ public class TestBase {
 
   @Autowired
   private FolioModuleMetadata moduleMetadata;
-
-  @BeforeEach
-  void setUp() {
-    FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(
-      AsyncFolioExecutionContext.builder()
-        .tenantId(TEST_TENANT)
-        .moduleMetadata(moduleMetadata)
-        .okapiUrl(getOkapiUrl()).build());
-  }
 
   public static String getOkapiUrl() {
     return String.format("http://localhost:%s", WIRE_MOCK_PORT);


### PR DESCRIPTION
https://issues.folio.org/browse/MODEBSNET-58

Delete the TestBase#setUp method.

Reasons:

* The tests don't need a FolioExecutionContext, they still succeed when deleting setUp().
* The endFolioExecutionContext is missing, this may influence other tests in future.
* Each test should use a different tenant id to test that FolioExecutionContext and tenant are correctly set.

Note that proper tenant separation handling is critical to many multi-tenancy implementers making correct FolioExecutionContext usage and testing an important non-functional requirement.