### PR TITLE
[MODEBSNET-59]. Migrate to folio-spring-support v7.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-base.version>6.0.1</folio-spring-base.version>
+    <folio-spring-base.version>7.0.0</folio-spring-base.version>
     <json.version>20210307</json.version>
     <log4j.version>2.19.0</log4j.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>


### PR DESCRIPTION
## Purpose
mod-ebsconet does not use cql, so we just need to increase folio-spring-base to 7.00

https://issues.folio.org/browse/MODEBSNET-59