### PR TITLE
MODEBSNET-62: Delete unused Kafka and database references

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -122,50 +122,6 @@
       {
         "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=80.0"
-      },
-      {
-        "name": "DB_HOST",
-        "value": "postgres"
-      },
-      {
-        "name": "DB_PORT",
-        "value": "5432"
-      },
-      {
-        "name": "DB_USERNAME",
-        "value": "folio_admin"
-      },
-      {
-        "name": "DB_PASSWORD",
-        "value": "folio_admin"
-      },
-      {
-        "name": "DB_DATABASE",
-        "value": "okapi_modules"
-      },
-      {
-        "name": "DB_QUERYTIMEOUT",
-        "value": "60000"
-      },
-      {
-        "name": "DB_CHARSET",
-        "value": "UTF-8"
-      },
-      {
-        "name": "DB_MAXPOOLSIZE",
-        "value": "5"
-      },
-      {
-        "name": "KAFKA_HOST",
-        "value": "10.0.2.15"
-      },
-      {
-        "name": "KAFKA_PORT",
-        "value": "9092"
-      },
-      {
-        "name": "ENV",
-        "value": "folio"
       }
     ]
   }

--- a/run-env.sh
+++ b/run-env.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-DB_URL="jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}"
-OPTS="-Dspring.datasource.username=${DB_USERNAME} -Dspring.datasource.password=${DB_PASSWORD} -Dspring.datasource.url=${DB_URL}"
+OPTS=""
 export JAVA_OPTIONS="${JAVA_OPTIONS:-} ${OPTS}"


### PR DESCRIPTION
They are misleading because mod-ebsconet neither uses Kafka nor a database.