### PR TITLE
MODEBSNET-86: Spring Boot 3.3.6, tomcat-embed-core 10.1.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.6</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEBSNET-86

## Purpose

Fix mix-up of HTTP/2 requests and/or responses between users:

https://www.cve.org/CVERecord?id=CVE-2024-52317

## Approach

Upgrade Spring boot from 3.3.4 to 3.3.6.

This indirectly upgrades tomcat-embed-core from 10.1.30 to 10.1.33 with the security fix.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging