### PR TITLE
MODEBSNET-91/MODEBSNET-92. Run container as folio, not as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
 FROM folioci/alpine-jre-openjdk21:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
 USER root
+RUN apk upgrade --no-cache
+USER folio
 
 # Copy your fat jar to the container
-ENV APP_FILE mod-ebsconet-fat.jar
-
+ENV APP_FILE mod-ebsconet.jar
 # - should be a single jar file
 ARG JAR_FILE=./target/*.jar
 # - copy
 COPY ${JAR_FILE} ${JAVA_APP_DIR}/${APP_FILE}
-
-ARG RUN_ENV_FILE=run-env.sh
-
-COPY ${RUN_ENV_FILE} ${JAVA_APP_DIR}/
-RUN chmod 755 ${JAVA_APP_DIR}/${RUN_ENV_FILE}
 
 # Expose this port locally in the container.
 EXPOSE 8081

--- a/run-env.sh
+++ b/run-env.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-OPTS=""
-export JAVA_OPTIONS="${JAVA_OPTIONS:-} ${OPTS}"


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODEBSNET-91
https://folio-org.atlassian.net/browse/MODEBSNET-92

### **Approach**
Remove unnesessary file
Standartize dockerfile to use folio user instead of root
---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
